### PR TITLE
Enable connectivity for clusters in all hosting environments

### DIFF
--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -174,11 +174,12 @@ spec:
           credentials:
             source: Secret
             secretRef:
-              namespace: crossplane-system
               key: kubeconfig
       patches:
         - fromFieldPath: spec.id
           toFieldPath: metadata.name
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.credentials.secretRef.namespace
         # This ProviderConfig uses the above EKS cluster's connection secret as
         # its credentials secret.
         - fromFieldPath: "metadata.uid"

--- a/cluster/gke/composition.yaml
+++ b/cluster/gke/composition.yaml
@@ -17,6 +17,12 @@ spec:
           forProvider:
             initialClusterVersion: "1.16"
             location: us-west2
+            masterAuth:
+              # setting this master auth user name enables basic auth so that a client (e.g.,
+              # provider-helm), can connect with the generated kubeconfig from the connection secret
+              username: admin
+            masterAuthorizedNetworksConfig:
+              enabled: false
             ipAllocationPolicy:
               useIpAliases: true
               clusterSecondaryRangeName: pods
@@ -105,11 +111,12 @@ spec:
           credentials:
             source: Secret
             secretRef:
-              namespace: crossplane-system
               key: kubeconfig
       patches:
         - fromFieldPath: spec.id
           toFieldPath: metadata.name
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.credentials.secretRef.namespace
         # This ProviderConfig uses the above GKE cluster's connection secret as
         # its credentials secret.
         - fromFieldPath: "metadata.uid"

--- a/examples/cluster-aws.yaml
+++ b/examples/cluster-aws.yaml
@@ -6,7 +6,7 @@ spec:
   compositionSelector:
     matchLabels:
       provider: AWS
-  id: multik8s-cluster
+  id: multik8s-cluster-aws
   parameters:
     nodes:
       count: 3
@@ -16,6 +16,6 @@ spec:
         prometheus:
           version: "10.0.2"
     networkRef:
-      id: multik8s-network
+      id: multik8s-network-aws
   writeConnectionSecretToRef:
-    name: cluster-conn
+    name: cluster-conn-aws

--- a/examples/cluster-gcp.yaml
+++ b/examples/cluster-gcp.yaml
@@ -6,7 +6,7 @@ spec:
   compositionSelector:
     matchLabels:
       provider: GCP
-  id: multik8s-cluster
+  id: multik8s-cluster-gcp
   parameters:
     nodes:
       count: 3
@@ -16,6 +16,6 @@ spec:
         prometheus:
           version: "10.0.2"
     networkRef:
-      id: multik8s-network
+      id: multik8s-network-gcp
   writeConnectionSecretToRef:
-    name: cluster-conn
+    name: cluster-conn-gcp

--- a/examples/network-aws.yaml
+++ b/examples/network-aws.yaml
@@ -3,9 +3,9 @@ kind: Network
 metadata:
   name: network-aws
 spec:
-  id: multik8s-network
+  id: multik8s-network-aws
   clusterRef:
-    id: multik8s-cluster
+    id: multik8s-cluster-aws
   compositionSelector:
     matchLabels:
       provider: AWS

--- a/examples/network-gcp.yaml
+++ b/examples/network-gcp.yaml
@@ -3,9 +3,9 @@ kind: Network
 metadata:
   name: network-gcp
 spec:
-  id: multik8s-network
+  id: multik8s-network-gcp
   clusterRef:
-    id: multik8s-cluster
+    id: multik8s-cluster-gcp
   compositionSelector:
     matchLabels:
       provider: GCP


### PR DESCRIPTION

* stop hard coding connection secret namespaces, set providerconfig.helm.release.io to look for secrets in the parent XR namespace
* enable GKE cluster basic auth so kubeconfig can actually connect
* update examples to avoid conflicts when run all together 