### PR TITLE
Set GKE cluster version to 1.18 (1.16 no longer supported) and bump package to v0.0.5 - README missed v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cp kubectl-crossplane /usr/local/bin
 #### Install the Platform Configuration
 
 ```console
-PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-multi-k8s:v0.0.3
+PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-multi-k8s:v0.0.5
 
 kubectl crossplane install configuration ${PLATFORM_CONFIG}
 kubectl get pkg
@@ -174,7 +174,7 @@ Set these to match your settings:
 UPBOUND_ORG=acme
 UPBOUND_ACCOUNT_EMAIL=me@acme.io
 REPO=platform-ref-multi-k8s
-VERSION_TAG=v0.0.3
+VERSION_TAG=v0.0.5
 REGISTRY=registry.upbound.io
 PLATFORM_CONFIG=${REGISTRY:+$REGISTRY/}${UPBOUND_ORG}/${REPO}:${VERSION_TAG}
 ```

--- a/cluster/gke/composition.yaml
+++ b/cluster/gke/composition.yaml
@@ -15,7 +15,7 @@ spec:
         kind: GKECluster
         spec:
           forProvider:
-            initialClusterVersion: "1.16"
+            initialClusterVersion: "1.18"
             location: us-west2
             masterAuth:
               # setting this master auth user name enables basic auth so that a client (e.g.,


### PR DESCRIPTION
This PR bumps the composition's GKE cluster version to v.18, since 1.16 is no longer supported in GCP.  We can't go any higher than that due to >= 1.19 requiring more advanced forms of auth that we haven't fully supported yet.  These are captured in:

https://github.com/crossplane-contrib/provider-helm/issues/72
https://github.com/crossplane/provider-gcp/issues/101

Also bumping the readme to v0.0.5 in prep for the new release - we already released v0.0.4 but we missed it in the readme, so we'll just go to the next release now.