### PR TITLE
fix: Remove unnecessary azure provider in dependsOn

### DIFF
--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -102,7 +102,5 @@ spec:
       version: ">=v0.14.0-0"
     - provider: registry.upbound.io/crossplane/provider-gcp
       version: ">=v0.18.0-0"
-    - provider: registry.upbound.io/crossplane/provider-azure
-      version: ">=v0.13.0-0"
     - provider: registry.upbound.io/crossplane/provider-helm
       version: ">=v0.3.6-0"


### PR DESCRIPTION
Currently the config pkg will be unhealthy if azure provider is not installed, which is unnecessary and not used anywhere.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
