### PR TITLE
feat(provider-aws): changes for provider-aws v0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ kubectl delete providers.pkg.crossplane.io provider-helm
   * [composition-aws.yaml](cluster/composition-aws.yaml) includes (transitively):
     * `EKSCluster`
     * `NodeGroup`
-    * `IAMRole`
-    * `IAMRolePolicyAttachment`
+    * `Role`
+    * `RolePolicyAttachment`
     * `HelmReleases` for Prometheus and other cluster services.
   * [composition-gcp.yaml](cluster/composition-gcp.yaml) includes (transitively):
     * `GKECluster`

--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -11,8 +11,8 @@ spec:
     kind: EKS
   resources:
     - base:
-        apiVersion: identity.aws.crossplane.io/v1beta1
-        kind: IAMRole
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: Role
         metadata:
           labels:
             role: controlplane
@@ -36,8 +36,8 @@ spec:
                 ]
               }
     - base:
-        apiVersion: identity.aws.crossplane.io/v1beta1
-        kind: IAMRolePolicyAttachment
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
         spec:
           forProvider:
             policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
@@ -77,8 +77,8 @@ spec:
       connectionDetails:
         - fromConnectionSecretKey: kubeconfig
     - base:
-        apiVersion: identity.aws.crossplane.io/v1beta1
-        kind: IAMRole
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: Role
         metadata:
           labels:
             role: nodegroup
@@ -102,8 +102,8 @@ spec:
                 ]
               }
     - base:
-        apiVersion: identity.aws.crossplane.io/v1beta1
-        kind: IAMRolePolicyAttachment
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
         spec:
           forProvider:
             policyArn: arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
@@ -112,8 +112,8 @@ spec:
               matchLabels:
                 role: nodegroup
     - base:
-        apiVersion: identity.aws.crossplane.io/v1beta1
-        kind: IAMRolePolicyAttachment
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
         spec:
           forProvider:
             policyArn: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
@@ -122,8 +122,8 @@ spec:
               matchLabels:
                 role: nodegroup
     - base:
-        apiVersion: identity.aws.crossplane.io/v1beta1
-        kind: IAMRolePolicyAttachment
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
         spec:
           forProvider:
             policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -99,7 +99,7 @@ spec:
     version: ">=v1.0.0-0"
   dependsOn:
     - provider: registry.upbound.io/crossplane/provider-aws
-      version: ">=v0.14.0-0"
+      version: ">=v0.22.0-0"
     - provider: registry.upbound.io/crossplane/provider-gcp
       version: ">=v0.18.0-0"
     - provider: registry.upbound.io/crossplane/provider-helm


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

since provider-aws v0.22.0
All IAM resources used to reside in identity group and they had prefixed names like IAMRole. In provider-aws v0.22.0 release, all of them moved to a new group called iam and renamed to drop the prefix, i.e. IAMRole -> Role. In addition, all of them are now v1beta1 resources.

ref: https://github.com/crossplane/provider-aws/releases/tag/v0.22.0

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
