### PR TITLE
fix: dependencies using xpkgs.upbound.io

### DIFF
--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -98,9 +98,9 @@ spec:
   crossplane:
     version: ">=v1.0.0-0"
   dependsOn:
-    - provider: registry.upbound.io/crossplane/provider-aws
+    - provider: xpkgs.upbound.io/crossplane-contrib/provider-aws
       version: ">=v0.22.0-0"
-    - provider: registry.upbound.io/crossplane/provider-gcp
+    - provider: xpkgs.upbound.io/crossplane-contrib/provider-gcp
       version: ">=v0.18.0-0"
-    - provider: registry.upbound.io/crossplane/provider-helm
+    - provider: xpkgs.upbound.io/crossplane-contrib/provider-helm
       version: ">=v0.9.0-0"

--- a/development.md
+++ b/development.md
@@ -26,9 +26,9 @@ kubectl apply -f hack/crossplane-cluster-admin-rolebinding.yaml
 ## `provider-aws` and `provider-helm`
 
 ```console
-PROVIDER_AWS=registry.upbound.io/crossplane/provider-aws:v0.14.0
-PROVIDER_GCP=registry.upbound.io/crossplane/provider-gcp:v0.13.0
-PROVIDER_HELM=registry.upbound.io/crossplane/provider-helm:v0.3.7
+PROVIDER_AWS=xpkgs.upbound.io/crossplane-contrib/provider-aws:v0.22.0
+PROVIDER_GCP=xpkgs.upbound.io/crossplane-contrib/provider-gcp:v0.18.0
+PROVIDER_HELM=xpkgs.upbound.io/crossplane-contrib/provider-helm:v0.9.0
 
 kubectl crossplane install provider ${PROVIDER_AWS}
 kubectl crossplane install provider ${PROVIDER_GCP}


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

The Configuration's dependencies specified were referencing providers from `registry.upbound.io`,
instead should now be using public Packages available through `xpkgs.upbound.io`, 
e.g. `xpkg.upbound.io/crossplane-contrib/provider-helm` for [provider-helm](https://marketplace.upbound.io/providers/crossplane-contrib/provider-helm/v0.12.0). 
Ideally, we should also move to upbound official providers too, as already done for other similar repositories, e.g. https://github.com/upbound/platform-ref-aws/pull/69/files and https://github.com/upbound/platform-ref-aws/commit/ea3579cc2344502f59fc4f3aa21a4cb87bd9ee59, but that will require more effort and the proposed changes should be enough to have a working Configuration.

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually packaged and deployed successfully.
